### PR TITLE
fix breaking dependencies upon update of sdk release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ members = [
 ]
 
 [dependencies]
-log = { version = "0.4", features = ["std"], git = "https://github.com/mesalock-linux/log-sgx" }
-regex = { version = "1.0.3", optional = true, git = "https://github.com/mesalock-linux/regex-sgx" }
-termcolor = { version = "1.0.5", optional = true, git = "https://github.com/mesalock-linux/termcolor-sgx" }
-humantime = { version = "1.3", optional = true, git = "https://github.com/mesalock-linux/humantime-sgx" }
+log = { rev="sgx_1.1.3", features = ["std"], git = "https://github.com/mesalock-linux/log-sgx" }
+regex = { rev="sgx_1.1.3", optional = true, git = "https://github.com/mesalock-linux/regex-sgx" }
+termcolor = { rev="sgx_1.1.3", optional = true, git = "https://github.com/mesalock-linux/termcolor-sgx" }
+humantime = { rev="sgx_1.1.3", optional = true, git = "https://github.com/mesalock-linux/humantime-sgx" }
 #atty = { version = "0.2.5", optional = true }
 sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 


### PR DESCRIPTION
mesalock-linux dependencies should be referenced by tag. otherwise the next release of 1.1.4 will break these deps (as the 1.1.3 does for 1.1.2)
would need to be fixed for many other mesalock crates.. rustls, yasna and probably others)